### PR TITLE
Add initial pipeline modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ src/
   streamlit_app.py        # interface visual para seleção do jogo e visualização de cortes
   services/
     sofascscore.py        # integração básica com SofaScore
+    video_downloader.py   # utilitário para baixar vídeos
   pipelines/
-    video_pipeline.py     # pipeline de corte e análise (esboço)
+    video_pipeline.py     # pipeline de corte e análise
+    analysis.py           # esboço de análise tática
 ```
 
 ## Dependências
@@ -27,4 +29,13 @@ pip install -r requirements.txt
 ```bash
 streamlit run src/streamlit_app.py
 ```
+
+## Arquitetura sugerida
+
+1. **Detecção de eventos**: `event_detection.fetch_critical_events` consulta a API do SofaScore e retorna apenas os incidentes relevantes.
+2. **Download/streaming de vídeo**: `VideoDownloader` pode ser usado para obter o arquivo bruto do jogo.
+3. **Corte e análise**: `VideoPipeline` recebe o vídeo completo e a lista de eventos, gerando clipes individuais para cada incidente. Etapas de visão computacional e análise por LLM podem ser acopladas nessa fase (ver `analysis.PlayAnalyzer`).
+4. **Interface**: o aplicativo Streamlit permite selecionar o jogo, fazer upload do vídeo completo e assistir aos clipes gerados.
+
+> **Nota**: para executar este projeto é necessário que as dependências estejam instaladas. Caso esteja em um ambiente sem acesso à internet, providencie um cache local dos pacotes ou ajuste o `requirements.txt` conforme sua disponibilidade.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ultralytics
 pydub
 moviepy
 openai-whisper
+openai
 requests
 beautifulsoup4
 playwright

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for the IntelliTatico project."""
+
+__all__ = []

--- a/src/event_detection.py
+++ b/src/event_detection.py
@@ -1,6 +1,6 @@
 from typing import List, Dict
 
-from services.sofascscore import SofaScoreClient
+from services import SofaScoreClient
 
 
 def fetch_critical_events(match_id: int) -> List[Dict]:

--- a/src/pipelines/__init__.py
+++ b/src/pipelines/__init__.py
@@ -1,0 +1,3 @@
+from .video_pipeline import VideoPipeline
+
+__all__ = ["VideoPipeline"]

--- a/src/pipelines/analysis.py
+++ b/src/pipelines/analysis.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any
+
+
+class PlayAnalyzer:
+    """Placeholder class for play analysis using LLMs and CV models."""
+
+    def analyze(self, clip: Path) -> str:
+        """Return textual analysis for a given play clip."""
+        # This would call an LLM or CV model to analyze the play.
+        # Actual implementation depends on available models/APIs.
+        return "analysis placeholder"
+
+
+__all__ = ["PlayAnalyzer"]

--- a/src/pipelines/video_pipeline.py
+++ b/src/pipelines/video_pipeline.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import List, Dict
 
+from moviepy.editor import VideoFileClip
+
 
 class VideoPipeline:
     def __init__(self, output_dir: Path) -> None:
@@ -9,8 +11,24 @@ class VideoPipeline:
 
     def process_events(self, video_path: Path, events: List[Dict]) -> List[Path]:
         """Given a full match video and event list, return paths to clips."""
-        # TODO: implement video cutting and analysis
         clips: List[Path] = []
+
+        video = VideoFileClip(str(video_path))
+        for idx, event in enumerate(events):
+            minute = event.get("time", {}).get("minute", 0)
+            second = event.get("time", {}).get("second", 0)
+            event_time = minute * 60 + second
+
+            start = max(0, event_time - 5)
+            end = min(video.duration, event_time + 5)
+
+            clip = video.subclip(start, end)
+            out_name = f"clip_{idx}_{event.get('incidentType', 'event')}.mp4"
+            out_path = self.output_dir / out_name
+            clip.write_videofile(str(out_path), codec="libx264", audio=False, verbose=False, logger=None)
+            clips.append(out_path)
+
+        video.close()
         return clips
 
 

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,4 @@
+from .sofascscore import SofaScoreClient
+from .video_downloader import VideoDownloader
+
+__all__ = ["SofaScoreClient", "VideoDownloader"]

--- a/src/services/video_downloader.py
+++ b/src/services/video_downloader.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+
+class VideoDownloader:
+    """Simple utility to download a video file from a given URL."""
+
+    def __init__(self, session: Optional[requests.Session] = None) -> None:
+        self.session = session or requests.Session()
+
+    def download(self, url: str, dest: Path) -> Path:
+        resp = self.session.get(url, stream=True)
+        resp.raise_for_status()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+        return dest
+
+
+__all__ = ["VideoDownloader"]

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -10,9 +10,12 @@ def main() -> None:
     match_id = st.text_input("Match ID from SofaScore")
     video_path = st.file_uploader("Upload full match video")
 
+    if "output_dir" not in st.session_state:
+        st.session_state["output_dir"] = Path("outputs")
+
     if st.button("Process") and match_id and video_path is not None:
         events = fetch_critical_events(int(match_id))
-        pipeline = VideoPipeline(output_dir=st.session_state.get("output_dir"))
+        pipeline = VideoPipeline(output_dir=st.session_state["output_dir"])
         clips = pipeline.process_events(Path(video_path.name), events)
         st.write(f"Generated {len(clips)} clips")
         for clip in clips:


### PR DESCRIPTION
## Summary
- flesh out the video pipeline with MoviePy cutting
- add utility to download videos
- expose service and pipeline modules
- basic PlayAnalyzer placeholder
- improve Streamlit app default output directory
- document updated project structure and architecture
- update dependencies list

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_685b71ec0ae88323bd787c1d5d4d795d