### PR TITLE
Improve match selection workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Sistema modular para gerar cortes automáticos de jogos de futebol com análise tática utilizando IA.
 
+Esta base contém um esboço inicial do projeto com capacidade de buscar um jogo a partir dos nomes dos times utilizando a API não oficial do SofaScore. O processo de corte em vídeo ainda é um "TODO", mas a estrutura modular já permite evoluções rápidas.
+
 ## Estrutura
 
 ```
@@ -27,4 +29,6 @@ pip install -r requirements.txt
 ```bash
 streamlit run src/streamlit_app.py
 ```
+
+Ao abrir o app, informe o nome dos dois times e clique em **Find match** para que o ID do jogo seja buscado automaticamente.
 

--- a/src/services/sofascscore.py
+++ b/src/services/sofascscore.py
@@ -4,17 +4,32 @@ from typing import List, Dict
 
 class SofaScoreClient:
     BASE_URL = "https://api.sofascore.com/api/v1"
+    DEFAULT_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
-    def __init__(self, session: requests.Session | None = None) -> None:
+    def __init__(self, session: requests.Session | None = None, headers: Dict | None = None) -> None:
         self.session = session or requests.Session()
+        self.headers = headers or self.DEFAULT_HEADERS
 
     def get_match_events(self, match_id: int) -> List[Dict]:
         """Fetch events for a given match using the unofficial SofaScore API."""
         url = f"{self.BASE_URL}/event/{match_id}/incidents"
-        resp = self.session.get(url)
+        resp = self.session.get(url, headers=self.headers)
         resp.raise_for_status()
         data = resp.json()
         return data.get("incidents", [])
+
+    def search_match(self, home_team: str, away_team: str) -> int | None:
+        """Find a match ID by team names using the search endpoint."""
+        query = f"{home_team} {away_team}"
+        url = f"{self.BASE_URL}/search/all/{query}"
+        resp = self.session.get(url, headers=self.headers)
+        resp.raise_for_status()
+        data = resp.json()
+        for event in data.get("events", []):
+            name = event.get("name", "").lower()
+            if home_team.lower() in name and away_team.lower() in name:
+                return event.get("id")
+        return None
 
 
 __all__ = ["SofaScoreClient"]

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -3,16 +3,32 @@ import streamlit as st
 
 from event_detection import fetch_critical_events
 from pipelines.video_pipeline import VideoPipeline
+from services.sofascscore import SofaScoreClient
 
 
 def main() -> None:
     st.title("IntelliTatico")
-    match_id = st.text_input("Match ID from SofaScore")
+
+    home_team = st.text_input("Home team")
+    away_team = st.text_input("Away team")
+
+    match_id = st.session_state.get("match_id")
+    if st.button("Find match") and home_team and away_team:
+        client = SofaScoreClient()
+        found = client.search_match(home_team, away_team)
+        if found:
+            st.session_state["match_id"] = found
+            match_id = found
+            st.success(f"Found match ID: {found}")
+        else:
+            st.error("Match not found")
+
+    st.write(f"Selected match ID: {match_id if match_id else 'None'}")
     video_path = st.file_uploader("Upload full match video")
 
     if st.button("Process") and match_id and video_path is not None:
         events = fetch_critical_events(int(match_id))
-        pipeline = VideoPipeline(output_dir=st.session_state.get("output_dir"))
+        pipeline = VideoPipeline(output_dir=Path("outputs"))
         clips = pipeline.process_events(Path(video_path.name), events)
         st.write(f"Generated {len(clips)} clips")
         for clip in clips:


### PR DESCRIPTION
## Summary
- implement basic match search via SofaScore API
- update Streamlit app to find matches by team names
- document match lookup workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b75b4e7848323a30c2b8291076855