### PR TITLE
Add match search and basic clip pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@ pip install -r requirements.txt
 streamlit run src/streamlit_app.py
 ```
 
+
+## Arquitetura
+
+O projeto está dividido em módulos independentes para facilitar extensão:
+
+- `services/` contem wrappers para integração com APIs externas como SofaScore.
+- `event_detection.py` concentra lógica de busca de eventos críticos de uma partida.
+- `pipelines/` possui pipelines de processção de vídeo para gerar os cortes.
+- `streamlit_app.py` oferece uma interface simples para seleção do jogo e visualização dos clipes.
+
+### Pipeline básica
+
+1. `search_match` localiza a partida no SofaScore.
+2. `fetch_critical_events` baixa incidentes relevantes.
+3. `VideoPipeline.process_events` recorta o vídeo baseando-se nos minutos dos eventos.
+
+Essa estrutura serve de ponto inicial para evoluir com detecção de jogadas via visão computacional e análise tática com IA.
+

--- a/src/event_detection.py
+++ b/src/event_detection.py
@@ -11,4 +11,13 @@ def fetch_critical_events(match_id: int) -> List[Dict]:
     return [e for e in events if e.get("incidentType") in critical_types]
 
 
-__all__ = ["fetch_critical_events"]
+def search_match_id(home_team: str, away_team: str) -> int | None:
+    """Return the match id if found on SofaScore."""
+    client = SofaScoreClient()
+    matches = client.search_match(home_team, away_team)
+    if not matches:
+        return None
+    return matches[0].get("id")
+
+
+__all__ = ["fetch_critical_events", "search_match_id"]

--- a/src/pipelines/video_pipeline.py
+++ b/src/pipelines/video_pipeline.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import List, Dict
 
+from moviepy.video.io.ffmpeg_tools import ffmpeg_extract_subclip
+
 
 class VideoPipeline:
     def __init__(self, output_dir: Path) -> None:
@@ -9,8 +11,14 @@ class VideoPipeline:
 
     def process_events(self, video_path: Path, events: List[Dict]) -> List[Path]:
         """Given a full match video and event list, return paths to clips."""
-        # TODO: implement video cutting and analysis
         clips: List[Path] = []
+        for idx, event in enumerate(events, start=1):
+            minute = event.get("time", {}).get("minute", 0)
+            start = max(minute * 60 - 10, 0)
+            end = start + 20
+            out_path = self.output_dir / f"clip_{idx}.mp4"
+            ffmpeg_extract_subclip(str(video_path), start, end, targetname=str(out_path))
+            clips.append(out_path)
         return clips
 
 

--- a/src/services/sofascscore.py
+++ b/src/services/sofascscore.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 
 class SofaScoreClient:
     BASE_URL = "https://api.sofascore.com/api/v1"
+    DEFAULT_HEADERS = {"User-Agent": "Mozilla/5.0"}
 
     def __init__(self, session: requests.Session | None = None) -> None:
         self.session = session or requests.Session()
@@ -11,10 +12,27 @@ class SofaScoreClient:
     def get_match_events(self, match_id: int) -> List[Dict]:
         """Fetch events for a given match using the unofficial SofaScore API."""
         url = f"{self.BASE_URL}/event/{match_id}/incidents"
-        resp = self.session.get(url)
+        resp = self.session.get(url, headers=self.DEFAULT_HEADERS)
         resp.raise_for_status()
         data = resp.json()
         return data.get("incidents", [])
+
+    def search_match(self, home_team: str, away_team: str) -> List[Dict]:
+        """Search for a match using the unofficial SofaScore API."""
+        query = f"{home_team} {away_team}"
+        encoded = requests.utils.quote(query)
+        url = f"{self.BASE_URL}/search/all/{encoded}"
+        resp = self.session.get(url, headers=self.DEFAULT_HEADERS)
+        resp.raise_for_status()
+        data = resp.json()
+        events = data.get("events", [])
+        filtered: List[Dict] = []
+        for event in events:
+            home = event.get("homeTeam", {}).get("name", "").lower()
+            away = event.get("awayTeam", {}).get("name", "").lower()
+            if home_team.lower() in home and away_team.lower() in away:
+                filtered.append(event)
+        return filtered
 
 
 __all__ = ["SofaScoreClient"]

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,18 +1,23 @@
 from pathlib import Path
 import streamlit as st
 
-from event_detection import fetch_critical_events
+from event_detection import fetch_critical_events, search_match_id
 from pipelines.video_pipeline import VideoPipeline
 
 
 def main() -> None:
     st.title("IntelliTatico")
-    match_id = st.text_input("Match ID from SofaScore")
+    home_team = st.text_input("Home team")
+    away_team = st.text_input("Away team")
     video_path = st.file_uploader("Upload full match video")
 
-    if st.button("Process") and match_id and video_path is not None:
-        events = fetch_critical_events(int(match_id))
-        pipeline = VideoPipeline(output_dir=st.session_state.get("output_dir"))
+    if st.button("Process") and home_team and away_team and video_path is not None:
+        match_id = search_match_id(home_team, away_team)
+        if match_id is None:
+            st.error("Match not found")
+            return
+        events = fetch_critical_events(match_id)
+        pipeline = VideoPipeline(output_dir=Path("outputs"))
         clips = pipeline.process_events(Path(video_path.name), events)
         st.write(f"Generated {len(clips)} clips")
         for clip in clips:


### PR DESCRIPTION
## Summary
- integrate match search via SofaScore API
- search for match in Streamlit interface and process clips
- cut small clips around event minutes
- document basic architecture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b76be9afc8323b9a237a9620085d7